### PR TITLE
add live reload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ npm install
 ```sh
 $ cd react/docs
 $ bundle exec rake
-$ bundle exec jekyll serve -w
+$ bundle exec jekyll serve -w -L
 $ open http://localhost:4000/react/index.html
 ```
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -27,3 +27,9 @@ gem 'pygments.rb'
 
 # Avoid having to poll for changes on Windows
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?
+
+#Live reloading
+group :jekyll_plugins do
+  gem 'jekyll-livereload'
+end
+


### PR DESCRIPTION
There have configured **jekyll-livereload** plugin in `doc/Gemfile` to support live reloading the webpage.
update Gemfile and execute `bundle` to install dependence.
[Refers](https://github.com/RobertDeRose/jekyll-livereload) 