### PR TITLE
withRouter和connect高阶组件的调用顺序，withRouter 应该在前

### DIFF
--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -282,7 +282,7 @@ const ConnectedComment = enhance(CommentList);
 
 ```js
 // 不要这样做……
-const EnhancedComponent = connect(commentSelector)(withRouter(WrappedComponent))
+const EnhancedComponent = withRouter(connect(commentSelector)(WrappedComponent))
 
 // ……你可以使用一个功能组合工具
 // compose(f, g, h) 和 (...args) => f(g(h(...args)))是一样的


### PR DESCRIPTION
原写法: 
const EnhancedComponent = connect(commentSelector)(withRouter(WrappedComponent))会导致无法响应路由的改变
参看英文版，应为：
const EnhancedComponent = withRouter(connect(commentSelector)(WrappedComponent))